### PR TITLE
Feat/#1 splash screen

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -16,5 +16,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "embeddedLanguageFormatting": "auto",
-  "printWidth": 80
+  "printWidth": 80,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "Main + renderer",
+      "configurations": ["Main", "Renderer"],
+      "stopAll": true
+    }
+  ],
+  "configurations": [
+    {
+      "name": "Renderer",
+      "port": 9222,
+      "request": "attach",
+      "type": "chrome",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "Main",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "args": [".", "--remote-debugging-port=9222"],
+      "outputCapture": "std",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default [
       ...reactPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "react/prop-types": "off",
+      "react/react-in-jsx-scope": "off",
     },
     settings: { react: { version: "detect" } },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.1",
+        "react-spinners": "^0.17.0"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.9.0",
@@ -40,6 +42,7 @@
         "lint-staged": "^16.1.6",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^4.1.13",
         "typescript": "^5.9.2",
         "vite": "^5.4.20"
@@ -3830,6 +3833,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -8927,6 +8939,93 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proc-log": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
@@ -9071,6 +9170,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
+      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
+      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -9612,6 +9759,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paste-wise",
-  "productName": "paste-wise",
+  "productName": "PasteWise",
   "version": "1.0.0",
   "description": "Paste wisely, communicate better.",
   "main": ".vite/build/main.js",
@@ -56,6 +56,7 @@
     "lint-staged": "^16.1.6",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.2",
     "vite": "^5.4.20"
@@ -63,6 +64,8 @@
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.1",
+    "react-spinners": "^0.17.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import AppRouter from "./navigators/AppRouter";
+import SplashPage from "./pages/splash";
+
+const SHOW_MS = 2500;
+const FADE_MS = 300;
+
+function App() {
+  const [visible, setVisible] = useState(true);
+  const [fadeOut, setFadeOut] = useState(false);
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(
+      () => {
+        setFadeOut(true);
+      },
+      Math.max(0, SHOW_MS - FADE_MS),
+    );
+    const navTimer = setTimeout(() => {
+      setVisible(false);
+    }, SHOW_MS);
+
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(navTimer);
+    };
+  }, []);
+
+  return (
+    <>
+      <AppRouter />
+      {visible && (
+        <SplashPage fadeOut={fadeOut} version="1.0.0" fadeMs={FADE_MS} />
+      )}
+    </>
+  );
+}
+
+export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,13 @@ function App() {
   const [fadeOut, setFadeOut] = useState(false);
 
   useEffect(() => {
+    const hasSeenSplash = sessionStorage.getItem("pw_splash_seen");
+
+    if (hasSeenSplash) {
+      setVisible(false);
+      return;
+    }
+
     const fadeTimer = setTimeout(
       () => {
         setFadeOut(true);
@@ -18,6 +25,7 @@ function App() {
     );
     const navTimer = setTimeout(() => {
       setVisible(false);
+      sessionStorage.setItem("pw_splash_seen", "true");
     }, SHOW_MS);
 
     return () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,57 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import AppRouter from "./navigators/AppRouter";
 import SplashPage from "./pages/splash";
-
-const SHOW_MS = 2500;
-const FADE_MS = 300;
+import useSplashController from "./hooks/useSplashController";
 
 function App() {
-  const [visible, setVisible] = useState(true);
-  const [fadeOut, setFadeOut] = useState(false);
-  const skippedRef = useRef(false);
-  const fadeOutTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const removeSplashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  useEffect(() => {
-    const hasSeenSplash = sessionStorage.getItem("pw_splash_seen");
-
-    if (hasSeenSplash) {
-      setVisible(false);
-      return;
-    }
-
-    fadeOutTimeoutRef.current = setTimeout(
-      () => setFadeOut(true),
-      Math.max(0, SHOW_MS - FADE_MS),
-    );
-    removeSplashTimeoutRef.current = setTimeout(() => {
-      setVisible(false);
-      sessionStorage.setItem("pw_splash_seen", "true");
-    }, SHOW_MS);
-
-    return () => {
-      if (fadeOutTimeoutRef.current) clearTimeout(fadeOutTimeoutRef.current);
-      if (removeSplashTimeoutRef.current)
-        clearTimeout(removeSplashTimeoutRef.current);
-    };
-  }, []);
-
-  const handleSkipSplash = useCallback(() => {
-    if (skippedRef.current) {
-      return;
-    }
-    skippedRef.current = true;
-
-    if (fadeOutTimeoutRef.current) clearTimeout(fadeOutTimeoutRef.current);
-    if (removeSplashTimeoutRef.current)
-      clearTimeout(removeSplashTimeoutRef.current);
-
-    setFadeOut(true);
-    setTimeout(() => setVisible(false), FADE_MS);
-    sessionStorage.setItem("pw_splash_seen", "true");
-  }, []);
+  const { visible, fadeOut, fadeMs, handleSkipSplash } = useSplashController();
 
   return (
     <>
@@ -60,7 +12,7 @@ function App() {
         <SplashPage
           fadeOut={fadeOut}
           version="1.0.0"
-          fadeMs={FADE_MS}
+          fadeMs={fadeMs}
           onSkip={handleSkipSplash}
         />
       )}

--- a/src/hooks/useSplashController.ts
+++ b/src/hooks/useSplashController.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState, useRef, useCallback } from "react";
+
+const SHOW_MS = 2500;
+const FADE_MS = 300;
+
+function useSplashController() {
+  const [visible, setVisible] = useState(true);
+  const [fadeOut, setFadeOut] = useState(false);
+
+  const skippedRef = useRef(false);
+  const fadeOutTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeSplashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const clearAllSplashTimeouts = () => {
+    if (fadeOutTimeoutRef.current) clearTimeout(fadeOutTimeoutRef.current);
+    if (removeSplashTimeoutRef.current)
+      clearTimeout(removeSplashTimeoutRef.current);
+  };
+
+  useEffect(() => {
+    const hasSeenSplash = sessionStorage.getItem("pw_splash_seen");
+
+    if (hasSeenSplash) {
+      setVisible(false);
+      return;
+    }
+
+    fadeOutTimeoutRef.current = setTimeout(
+      () => setFadeOut(true),
+      Math.max(0, SHOW_MS - FADE_MS),
+    );
+    removeSplashTimeoutRef.current = setTimeout(() => {
+      setVisible(false);
+      sessionStorage.setItem("pw_splash_seen", "true");
+    }, SHOW_MS);
+
+    return () => {
+      clearAllSplashTimeouts();
+    };
+  }, []);
+
+  const handleSkipSplash = useCallback(() => {
+    if (skippedRef.current) {
+      return;
+    }
+    skippedRef.current = true;
+
+    clearAllSplashTimeouts();
+
+    setFadeOut(true);
+    setTimeout(() => setVisible(false), FADE_MS);
+    sessionStorage.setItem("pw_splash_seen", "true");
+  }, []);
+
+  return {
+    visible,
+    fadeOut,
+    fadeMs: FADE_MS,
+    handleSkipSplash,
+  };
+}
+
+export default useSplashController;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,23 +2,24 @@ import { app, BrowserWindow } from "electron";
 import path from "node:path";
 import started from "electron-squirrel-startup";
 
-// Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) {
   app.quit();
 }
 
 const createWindow = () => {
-  // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 900,
+    height: 560,
+    minWidth: 720,
+    minHeight: 480,
+    center: true,
     show: false,
+    useContentSize: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
     },
   });
 
-  // and load the index.html of the app.
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
   } else {
@@ -30,16 +31,18 @@ const createWindow = () => {
   mainWindow.once("ready-to-show", () => mainWindow.show());
 };
 
-app.on("ready", createWindow);
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
-  }
-});
-
-app.on("activate", () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
   }
 });

--- a/src/navigators/AppRouter.tsx
+++ b/src/navigators/AppRouter.tsx
@@ -1,0 +1,10 @@
+import { Routes, Route } from "react-router-dom";
+import HistoryPage from "@/pages/history";
+
+export default function AppRouter() {
+  return (
+    <Routes>
+      <Route path="/history" element={<HistoryPage />} />
+    </Routes>
+  );
+}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -1,0 +1,5 @@
+function HistoryPage() {
+  return <div className="min-h-screen p-8">History Page</div>;
+}
+
+export default HistoryPage;

--- a/src/pages/splash/LoadingIndicator.tsx
+++ b/src/pages/splash/LoadingIndicator.tsx
@@ -1,0 +1,19 @@
+import { SyncLoader } from "react-spinners";
+
+const LOADER_COLOR = "#98d8ff";
+const LOADER_SIZE = 10;
+const LOADER_SPEED = 0.4;
+
+function LoadingIndicator() {
+  return (
+    <div className="mt-10">
+      <SyncLoader
+        color={LOADER_COLOR}
+        size={LOADER_SIZE}
+        speedMultiplier={LOADER_SPEED}
+      />
+    </div>
+  );
+}
+
+export default LoadingIndicator;

--- a/src/pages/splash/LogoBox.tsx
+++ b/src/pages/splash/LogoBox.tsx
@@ -1,0 +1,11 @@
+function LogoBox() {
+  return (
+    <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-indigo-600 text-3xl shadow-xl">
+      <span role="img" aria-label="app logo">
+        📋
+      </span>
+    </div>
+  );
+}
+
+export default LogoBox;

--- a/src/pages/splash/ServiceTitle.tsx
+++ b/src/pages/splash/ServiceTitle.tsx
@@ -1,0 +1,12 @@
+function ServiceTitle() {
+  return (
+    <>
+      <h1 className="mb-2 text-4xl font-light text-slate-800">
+        Copy & <span className="font-bold text-blue-600">PasteWise</span>
+      </h1>
+      <p className="text-slate-500">Paste wisely, communicate better.</p>
+    </>
+  );
+}
+
+export default ServiceTitle;

--- a/src/pages/splash/VersionFooter.tsx
+++ b/src/pages/splash/VersionFooter.tsx
@@ -1,0 +1,13 @@
+type Props = {
+  version: string;
+};
+
+function VersionFooter({ version }: Props) {
+  return (
+    <footer className="absolute bottom-6 text-xs text-slate-400">
+      PasteWise v{version}
+    </footer>
+  );
+}
+
+export default VersionFooter;

--- a/src/pages/splash/index.tsx
+++ b/src/pages/splash/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import LogoBox from "./LogoBox";
 import ServiceTitle from "./ServiceTitle";
 import LoadingIndicator from "./LoadingIndicator";
@@ -7,13 +8,33 @@ type SplashPageProps = {
   fadeOut: boolean;
   version: string;
   fadeMs: number;
+  onSkip: () => void;
 };
 
 function SplashPage({
   fadeOut = false,
   version = "1.0.0",
   fadeMs = 300,
+  onSkip,
 }: SplashPageProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Space") {
+        onSkip();
+      }
+    };
+    const handleClick = () => {
+      onSkip();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("click", handleClick);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("click", handleClick);
+    };
+  }, [onSkip]);
+
   return (
     <main
       className={`fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-white transition-opacity ease-out ${fadeOut ? "pointer-events-none opacity-0" : "opacity-100"}`}

--- a/src/pages/splash/index.tsx
+++ b/src/pages/splash/index.tsx
@@ -1,0 +1,32 @@
+import LogoBox from "./LogoBox";
+import ServiceTitle from "./ServiceTitle";
+import LoadingIndicator from "./LoadingIndicator";
+import VersionFooter from "./VersionFooter";
+
+type SplashPageProps = {
+  fadeOut: boolean;
+  version: string;
+  fadeMs: number;
+};
+
+function SplashPage({
+  fadeOut = false,
+  version = "1.0.0",
+  fadeMs = 300,
+}: SplashPageProps) {
+  return (
+    <main
+      className={`fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-white transition-opacity ease-out ${fadeOut ? "pointer-events-none opacity-0" : "opacity-100"}`}
+      style={{ transitionDuration: `${fadeMs}ms`, willChange: "opacity" }}
+    >
+      <section className="flex flex-col items-center">
+        <LogoBox />
+        <ServiceTitle />
+        <LoadingIndicator />
+      </section>
+      <VersionFooter version={version} />
+    </main>
+  );
+}
+
+export default SplashPage;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,21 +1,18 @@
-// src/renderer.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import "./index.css"; // @import "tailwindcss"; 가 들어있는 파일
+import "./index.css";
+import { MemoryRouter } from "react-router-dom";
+import App from "./App";
 
-function App() {
-  return (
-    <div className="min-h-screen grid place-items-center">
-      <div className="space-y-2 text-center">
-        <h1 className="text-3xl font-bold">💖 Hello World!</h1>
-        <p>Welcome to your Electron application.</p>
-      </div>
-    </div>
-  );
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("Root element #root not found");
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+ReactDOM.createRoot(container).render(
   <React.StrictMode>
-    <App />
+    <MemoryRouter initialEntries={["/history"]}>
+      <App />
+    </MemoryRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## 📝 요약 (Summary)
**앱 실행 시 처음 1회 보여줄 Splash 화면**을 구현했습니다.
로고(📋), 앱 이름(PasteWise), 간단한 소개 문구, 로딩 애니메이션을 포함해서 UI를 구성했고,  
2.5초 동안 보여준 뒤 자동으로 사라지면서 `/history` 화면이 자연스럽게 드러나도록 했습니다.  

또한, 사용자가 기다리지 않고 바로 넘어가고 싶을 때를 대비해 **Enter / Space 키나 클릭**으로 즉시 스킵할 수 있게 했습니다.
중복 입력이나 이벤트가 여러 번 실행되는 걸 막기위해, `useRef`를 이용해서 **한 번만 동작**하도록 가드 플래그를 두었고,  
모든 `setTimeout`과 이벤트 리스너는 컴포넌트가 사라질 때 **클린업**이 되도록 처리했습니다.  

마지막으로 같은 실행 세션에서는 Splash가 한 번만 뜨도록 `sessionStorage`를 활용했습니다.  
앱을 완전히 종료하고 다시 실행하면 새 세션으로 판단해서 Splash를 다시 보여줍니다.


<br><br>

## ☑️ 작업 내용 (Task)

이번 PR에서 진행된 작업을 작성해주세요.

1. **UI 마크업 & 스타일**
    - [x]  로고 SVG/PNG 배치, 앱명 “PasteWise”, 서브카피(한 줄 소개) 추가
    - [x]  중앙 정렬된 레이아웃을 유지하고, **앱 창을 최소 크기(예: 720×480)까지 줄여도 UI가 깨지지 않도록 반응형 처리**
2. **타이머 전환 로직**
    - [x]  setTimeout(2500~3000ms) 후 /history로 라우팅
    - [x]  전환 시 **페이드 아웃(fade-out)** 효과(350ms) 적용
3. **스킵(입력 시 즉시 전환)**
    - [x]  키보드(Enter/Esc/Space), 마우스 클릭 시 즉시 /history로 이동
    - [x]  다중 이벤트 방지(중복 네비게이션 막기): **가드 플래그**(once)로 한 번만 작동
4. **상태 관리 & 클린업**
    - [x]  타이머/리스너 **클린업(clean-up)** 처리 (컴포넌트 언마운트 시 해제)
    - [x]  최초 진입 여부 sessionStorage 플래그: 같은 세션에서 재방문 시 스킵
5. **에러/로딩 대비(가드)**
    - [x]  전환 중 **중복 입력 무시**(디바운스 or 가드)

<br><br>

## 📸 스크린샷 (선택)

1. Splash 정면 스크린샷
<img width="841" height="551" alt="image" src="https://github.com/user-attachments/assets/283626e3-600a-4719-9c3a-e46697c260b2" />


2. Splash 화면 2~3초간 실행되고 history화면으로 전환
![splash 초기 (2)](https://github.com/user-attachments/assets/f7cc0e93-ca57-4d51-9005-85e34df888c1)


3. 마우스 클릭/ 엔터/ 스페이스바 입력 시 바로 전환
![splash 클릭이벤트 (1)](https://github.com/user-attachments/assets/1b48b961-1c37-4aa6-aaca-aba6f154a87b)


4. 콘솔 로그 캡처(전환 이벤트 1회만 발생하는지)
![splash 콘솔로그](https://github.com/user-attachments/assets/9057106e-3379-4fc7-b7aa-9ae9020d1a03)



<br><br>

## 🗂 참고/메모 (Notes)
 
- **라우터 선택 고민**  
   브라우저 라우터/해시 라우터 대신 Electron 환경에 적합한 **MemoryRouter** 사용했습니다.
   데스크톱 앱은 주소창이 없으니 URL 동기화가 필요 없어 MemoryRouter를 쓰면 경로 관리가 간단합니다.
   → URL 변경은 필요 없지만, 라우팅 상태 관리는 가능  

- **화면 전환 구조**  
   HistoryPage는 항상 렌더링해 두고, Splash를 맨 위에 `fixed`로 덮어두는 구조입니다.
   라우팅을 할 경우 끊겨보이는 현상이 발생하여 overlay 구조를 선택했습니다.
   Splash의 opacity를 줄이면, 자연스럽게 뒤에 있는 HistoryPage가 드러나도록 했습니다.

- **타이머 두 개 사용**  
    타이머와 이벤트 리스너가 언마운트 시 해제되지 않으면 메모리 누수와 예기치 않은 재실행 문제 발생할 수 있어
    → `useEffect` cleanup과 `useRef`로 클린업 함수가 실행되도록 했습니다. 

- **가드 플래그(useRef)**  
   여러 번 클릭하거나 키를 눌러도 Splash가 중복으로 종료되지 않게 `useRef`로 “이미 실행됨” 상태를 저장했습니다.  
   state로 하면 리렌더링이 발생할 수 있는데, ref는 렌더와 무관하게 값만 유지되어 useRef를 사용하게 되었습니다.

- **sessionStorage 선택 이유**  
   sessionStorage는 앱이 완전히 종료되면 초기화되므로  같은 실행 세션 안에서는 Splash 한 번만  보여지도록 했습니다.
   앱 재실행 시에는 다시 Splash 노출하도록 처리하였고, 재 실행 단위를 sessionStorage를 사용하여 세션마다 판단되도록 하였습니다.

<br><br>

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 확인
- [x] 최신 dev 브랜치 pull 완료
- [x] conflict 해결 완료
- [x] 코드 컨벤션 확인 (lint/format)
- [x] `console.log` 제거 및 불필요한 주석 정리
- [x] 브랜치명 확인
- [x] dependency 변경 시 기록
